### PR TITLE
feat: command轮询proto，双向心跳包在线状态检测

### DIFF
--- a/ClassIsland.Core/ClassIsland.Core.csproj
+++ b/ClassIsland.Core/ClassIsland.Core.csproj
@@ -28,6 +28,7 @@
     <Protobuf Include="Protobuf\Service\*.proto"/>
     <Protobuf Include="Protobuf\Server\*.proto"/>
     <Protobuf Include="Protobuf\Client\*.proto"/>
+    <Protobuf Include="Protobuf\Command\*.proto"/>
     <Protobuf Include="Protobuf\Enum\*.proto"/>
     <Protobuf Include="Protobuf\Management\*.proto"/>
   </ItemGroup>

--- a/ClassIsland.Core/Protobuf/Client/CommandCsReq.proto
+++ b/ClassIsland.Core/Protobuf/Client/CommandCsReq.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package ClassIsland.Core.Protobuf.Client;
+option csharp_namespace = "ClassIsland.Core.Protobuf.Client";
+
+message CommandCsReq {
+    string ClientUid = 1;
+}

--- a/ClassIsland.Core/Protobuf/Command/HeartBeat.proto
+++ b/ClassIsland.Core/Protobuf/Command/HeartBeat.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package ClassIsland.Core.Protobuf.Command;
+option csharp_namespace = "ClassIsland.Core.Protobuf.Command";
+
+message HeartBeat {
+    bool isOnline = 1;
+}

--- a/ClassIsland.Core/Protobuf/Enum/CommandType.proto
+++ b/ClassIsland.Core/Protobuf/Enum/CommandType.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package ClassIsland.Core.Protobuf.Enum;
+option csharp_namespace = "ClassIsland.Core.Protobuf.Enum";
+
+enum CommandType {
+    // heartbeat
+    Ping = 0;
+    Pong = 1;
+    // command
+    Notification = 2;
+    UpdateSettings = 3;
+}

--- a/ClassIsland.Core/Protobuf/Server/CommandScRsp.proto
+++ b/ClassIsland.Core/Protobuf/Server/CommandScRsp.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package ClassIsland.Core.Protobuf.Server;
+option csharp_namespace = "ClassIsland.Core.Protobuf.Server";
+
+import "Protobuf/Enum/Retcode.proto";
+import "Protobuf/Enum/CommandType.proto";
+
+message CommandScRsp {
+    Enum.Retcode Retcode = 1;
+    int64 CommandCount = 2;
+    repeated CommandPayload Payload = 3;
+    
+    message CommandPayload {
+        Enum.CommandType CommandType = 1;
+        bytes Payload = 2;
+    }
+}
+
+

--- a/ClassIsland.Core/Protobuf/Service/CommandManager.proto
+++ b/ClassIsland.Core/Protobuf/Service/CommandManager.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package ClassIsland.Core.Protobuf.Service;
+option csharp_namespace = "ClassIsland.Core.Protobuf.Service";
+
+import "Protobuf/Client/CommandCsReq.proto";
+import "Protobuf/Server/CommandScRsp.proto";
+import "Protobuf/Command/HeartBeat.proto";
+
+service CommandManager {
+    rpc ListCommand (Client.CommandCsReq) returns (Server.CommandScRsp);
+    
+    rpc CheckOnline (Command.HeartBeat) returns (Command.HeartBeat);
+}

--- a/ClassIsland/Services/Management/ClientRegisterService.cs
+++ b/ClassIsland/Services/Management/ClientRegisterService.cs
@@ -1,0 +1,6 @@
+namespace ClassIsland.Services.Management;
+
+public class ClientRegisterService
+{
+    
+}


### PR DESCRIPTION
决定抛弃双向流传输指令包，采用客户端定时轮询的方式，虽然会增加一点服务端的性能消耗 ~~，但是能偷个懒就偷一下吧反正有心跳包兜底不会出什么大乱子~~
